### PR TITLE
Remove code signing step

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -152,23 +152,6 @@ jobs:
           distribution: 'zulu'
       - run: ./gradlew copyToUpload -Prunmerge
         name: Build with Gradle
-        if: |
-          github.repository_owner != 'wpilibsuite' ||
-          (github.ref != 'refs/heads/main' && !startsWith(github.ref, 'refs/tags/v'))
-      - name: Import Developer ID Certificate
-        uses: wpilibsuite/import-signing-certificate@v2
-        with:
-          certificate-data: ${{ secrets.APPLE_CERTIFICATE_DATA }}
-          certificate-passphrase: ${{ secrets.APPLE_CERTIFICATE_PASSWORD }}
-          keychain-password: ${{ secrets.APPLE_KEYCHAIN_PASSWORD }}
-        if: |
-          github.repository_owner == 'wpilibsuite' &&
-          (github.ref == 'refs/heads/main' || startsWith(github.ref, 'refs/tags/v'))
-      - run: ./gradlew copyToUpload -Prunmerge -PdeveloperID=${{ secrets.APPLE_DEVELOPER_ID }}
-        name: Sign Binaries with Developer ID
-        if: |
-          github.repository_owner == 'wpilibsuite' &&
-          (github.ref == 'refs/heads/main' || startsWith(github.ref, 'refs/tags/v'))
       - uses: actions/upload-artifact@v4
         with:
           name: macOSUniversal


### PR DESCRIPTION
Static libraries don't need to be signed.